### PR TITLE
fix(Input): space overwriting previous character

### DIFF
--- a/packages/solid/components/Input/Input.tsx
+++ b/packages/solid/components/Input/Input.tsx
@@ -52,7 +52,7 @@ const Input: Component<InputProps> = props => {
       case 'space':
         newTitle =
           currentPosition > 0
-            ? inputText.slice(0, currentPosition - 1) + ' ' + inputText.slice(currentPosition)
+            ? inputText.slice(0, currentPosition) + ' ' + inputText.slice(currentPosition)
             : ' ' + inputText;
         currentPosition++;
         break;


### PR DESCRIPTION
## Description

within the KeyboardInput component, it was observed that the space key overrides the last character in the title. This fixes that bug

## Changes

- removes minus 1 from slice formatting input text on space

## Testing

In both Input and KeyboardInput, add a few characters and then a space. Make sure the space does not overwrite
