### PR TITLE
fix: Column and Rows with offset

### DIFF
--- a/packages/solid/components/Column/Column.tsx
+++ b/packages/solid/components/Column/Column.tsx
@@ -35,7 +35,11 @@ const Column: Component<ColumnProps> = (props: ColumnProps) => {
       onDown={chainFunctions<KeyHandler | undefined>(props.onDown, onDown)}
       selected={props.selected || 0}
       forwardFocus={onGridFocus}
-      onBeforeLayout={chainFunctions(props.onBeforeLayout, (elm, selected) => scroll(elm, selected))}
+      onBeforeLayout={
+        props.selected
+          ? chainFunctions(props.onBeforeLayout, (elm, selected) => scroll(elm, selected))
+          : undefined
+      }
       onSelectedChanged={chainFunctions(
         props.onSelectedChanged,
         props.scroll !== 'none' ? scroll : undefined

--- a/packages/solid/components/Column/Column.tsx
+++ b/packages/solid/components/Column/Column.tsx
@@ -38,7 +38,7 @@ const Column: Component<ColumnProps> = (props: ColumnProps) => {
       onBeforeLayout={
         props.selected
           ? chainFunctions(props.onBeforeLayout, (elm, selected) => scroll(elm, selected))
-          : undefined
+          : props.onBeforeLayout
       }
       onSelectedChanged={chainFunctions(
         props.onSelectedChanged,

--- a/packages/solid/components/Column/Column.types.ts
+++ b/packages/solid/components/Column/Column.types.ts
@@ -55,9 +55,9 @@ export interface ColumnProps extends UIComponentProps, ColumnStyleProperties {
   selected?: number;
 
   /**
-   * Allows adjusting the scroll by number of pixels
+   * Adjust the x position of the row. Initial value is Y
    */
-  scrollAdjustment?: number;
+  offset?: number;
 
   /**
    * Wrap the row so active goes back to the beginning of the row

--- a/packages/solid/components/Row/Row.stories.tsx
+++ b/packages/solid/components/Row/Row.stories.tsx
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -66,25 +66,23 @@ const buttons = (num = 8) => createItems(num);
 export const Basic = {
   render: args => {
     return (
-      <View width={2000} height={720}>
-        <Row autofocus {...args}>
-          {buttons}
-        </Row>
-      </View>
+      <Row autofocus {...args}>
+        {buttons}
+      </Row>
     );
   },
   args: {
     children: buttons,
     wrap: false,
-    scroll: 'edge',
-    x: 30
+    scroll: 'auto',
+    x: 100
   }
 };
 
 export const edgeScroll = {
   render: args => {
     return (
-      <Row width={1200} autofocus {...args}>
+      <Row autofocus {...args}>
         {buttons}
       </Row>
     );
@@ -93,7 +91,7 @@ export const edgeScroll = {
     children: buttons,
     scroll: 'edge',
     wrap: false,
-    x: 0
+    x: 100
   }
 };
 
@@ -111,7 +109,7 @@ export const AlwaysScroll = {
     children: buttons,
     scroll: 'always',
     wrap: false,
-    x: 0
+    x: 100
   }
 };
 
@@ -147,6 +145,6 @@ export const ScrollIndex = {
     children: buttons,
     scrollIndex: 4,
     wrap: false,
-    x: 0
+    x: 100
   }
 };

--- a/packages/solid/components/Row/Row.tsx
+++ b/packages/solid/components/Row/Row.tsx
@@ -35,7 +35,11 @@ const Row: Component<RowProps> = (props: RowProps) => {
       onLeft={chainFunctions(props.onLeft, onLeft)}
       onRight={chainFunctions(props.onRight, onRight)}
       forwardFocus={onGridFocus}
-      onBeforeLayout={chainFunctions(props.onBeforeLayout, (elm, selected) => scroll(elm, selected))}
+      onBeforeLayout={
+        props.selected
+          ? chainFunctions(props.onBeforeLayout, (elm, selected) => scroll(elm, selected))
+          : undefined
+      }
       onSelectedChanged={chainFunctions(
         props.onSelectedChanged,
         props.scroll !== 'none' ? scroll : undefined

--- a/packages/solid/components/Row/Row.tsx
+++ b/packages/solid/components/Row/Row.tsx
@@ -38,7 +38,7 @@ const Row: Component<RowProps> = (props: RowProps) => {
       onBeforeLayout={
         props.selected
           ? chainFunctions(props.onBeforeLayout, (elm, selected) => scroll(elm, selected))
-          : undefined
+          : props.onBeforeLayout
       }
       onSelectedChanged={chainFunctions(
         props.onSelectedChanged,

--- a/packages/solid/components/Row/Row.types.ts
+++ b/packages/solid/components/Row/Row.types.ts
@@ -51,9 +51,9 @@ export interface RowProps extends UIComponentProps, RowStyleProperties {
   ) => void;
 
   /**
-   * Allows adjusting the scroll by number of pixels
+   * Adjust the x position of the row. Initial value is X
    */
-  scrollAdjustment?: number;
+  offset?: number;
 
   /**
    * Wrap the row so active goes back to the beginning of the row


### PR DESCRIPTION
OK... scrollAdjust was not the thing. Adjustment was the original x, y position of the column. However, if the user changes the x, y position or wants to move the column or row - we'll that wasn't possible. Now there is an offset property (removed scrollAdjustment as that shouldn't be a thing) - the offset factors in the row or columns x, y position and user can set the offset property at anytime to move the row or column around on the screen. 

I also fixed timing issues if user scrolls to fast and we're in the middle of an animation by storing the _targetPosition and using that as the root.

Updated the stories to set Row x = 100 to show this working.

Also only do initial layout if there is a selected item