### PR TITLE
fix(ProgressBar): fix prop name so radius styles are applied

### DIFF
--- a/packages/solid/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/solid/components/ProgressBar/ProgressBar.stories.tsx
@@ -39,7 +39,7 @@ const meta: Meta<typeof ProgressBar> = {
       description: 'Percentage of current progress in a decimal format from 0 to 1',
       control: { type: 'number', step: 0.1, min: 0, max: 1.0 }
     },
-    borderRadius: {
+    radius: {
       description: 'Radius of the bar',
       control: { type: 'number', step: 1, min: 0, max: 50 }
     }
@@ -62,6 +62,6 @@ export const Basic: Story = {
     width: 500,
     height: theme.spacer.md,
     progress: 0.5,
-    borderRadius: theme.radius.xs
+    radius: theme.radius.xs
   }
 };


### PR DESCRIPTION
## Description

<!-- An explanation of why this PR has been opened. The more context provided, the easier to review the PR -->

Noticed this small issue while working on PR #48.`ProgressBar` types are setup to take `radius` not `borderRadius` to style the radius on the bar. This PR updates the documentation for clarity and updates the story for `ProgressBar`.

## Changes

<!-- A bulleted list of all the changes(anything that might not have been covered in the description) -->
- Updated radius prop name in docs
- Updated radius arg name in story

## Testing

<!-- step by step instructions to review this PR's changes -->

- [ ] fetch fix branch and run locally
- [ ] go to `ProgressBar` story and adjust `radius` control to see radius applied to bar
- [ ] compare to current at https://rdkcentral.github.io/solid-ui/
