### PR TITLE
fix: update exports to point to dist files, add `src` import for source file access

### DIFF
--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -7,12 +7,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./index.ts",
-      "types": "./index.ts"
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./utils": {
-      "import": "./utils/index.ts",
-      "types": "./utils/index.ts"
+      "import": "./dist/utils/index.js",
+      "types": "./dist/utils/index.d.ts"
+    },
+    "./src": {
+      "import": "./index.ts",
+      "types": "./index.ts"
     }
   },
   "files": [


### PR DESCRIPTION
## Description

This PR updates the `exports` property to point to the compiled dist files, it also adds a `src` export to support importing the uncompiled source files

## Changes

<!-- A bulleted list of all the changes(anything that might not have been covered in the description) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
