### PR TITLE
fix: ensure getThemeStyles ts def is included in build

### DIFF
--- a/packages/solid/utils/getThemeStyles.ts
+++ b/packages/solid/utils/getThemeStyles.ts
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ComponentStyleConfig } from '../types/types.js';
+import type { ComponentStyleConfig } from '../types/types.js';
 
 export declare function makeComponentStyles<T>(
   { themeKeys, base, themeStyles, tones, modes, modeKeys, toneKeys }: ComponentStyleConfig,


### PR DESCRIPTION
## Description

rename `getThemeStyles.d.ts` -> `getThemeStyles.ts` so it gets properly included by `tsc`

## Changes

<!-- A bulleted list of all the changes(anything that might not have been covered in the description) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
