### PR TITLE
fix: add asset alias, remove type alias

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "assets/*": ["./packages/solid/assets/*"]
+    }
+  }
+}

--- a/packages/solid/.storybook/preview.tsx
+++ b/packages/solid/.storybook/preview.tsx
@@ -16,10 +16,7 @@
  */
 /* @refresh reload */
 import { createRenderer, Config, loadFonts } from '@lightningtv/solid';
-import {
-  WebGlCoreRenderer,
-  SdfTextRenderer,
-} from "@lightningjs/renderer/webgl";
+import { WebGlCoreRenderer, SdfTextRenderer } from '@lightningjs/renderer/webgl';
 import { Inspector } from '@lightningjs/renderer/inspector';
 import fonts from '../../shared/fonts';
 import { themes } from '@storybook/theming';
@@ -32,8 +29,10 @@ Config.rendererOptions = {
   inspector: Inspector,
   devicePhysicalPixelRatio: 1,
   fontEngines: [SdfTextRenderer],
-  renderEngine: WebGlCoreRenderer,
+  renderEngine: WebGlCoreRenderer
 };
+
+Config.fontSettings.fontFamily = 'Arial';
 
 let dispose;
 

--- a/packages/solid/.storybook/vite.config.storybook.js
+++ b/packages/solid/.storybook/vite.config.storybook.js
@@ -61,7 +61,6 @@ const config = {
     alias: {
       theme: path.resolve(__dirname, '../../l3-ui-theme-base/theme.js'),
       utils: path.resolve(__dirname, '../../shared/utils/index.ts'),
-      types: path.resolve(__dirname, '../types/'),
       assets: path.resolve(__dirname, '../assets/')
     },
     dedupe: ['solid-js', '@lightningtv/solid']

--- a/packages/solid/.storybook/vite.config.storybook.js
+++ b/packages/solid/.storybook/vite.config.storybook.js
@@ -23,17 +23,6 @@ import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 import path from 'path';
 
-import viteBaseConfig from '../vite.config';
-
-viteBaseConfig.plugins.hexColorTransform = undefined;
-viteBaseConfig.resolve.alias = {
-  theme: path.resolve(__dirname, '../../l3-ui-theme-base/theme.js'),
-  utils: path.resolve(__dirname, '../../shared/utils/index.ts'),
-  assets: path.resolve(__dirname, '../assets/')
-};
-
-// export default defineConfig(viteBaseConfig);
-
 const config = {
   plugins: [
     solidPlugin({

--- a/packages/solid/.storybook/vite.config.storybook.js
+++ b/packages/solid/.storybook/vite.config.storybook.js
@@ -23,6 +23,17 @@ import { defineConfig } from 'vite';
 import solidPlugin from 'vite-plugin-solid';
 import path from 'path';
 
+import viteBaseConfig from '../vite.config';
+
+viteBaseConfig.plugins.hexColorTransform = undefined;
+viteBaseConfig.resolve.alias = {
+  theme: path.resolve(__dirname, '../../l3-ui-theme-base/theme.js'),
+  utils: path.resolve(__dirname, '../../shared/utils/index.ts'),
+  assets: path.resolve(__dirname, '../assets/')
+};
+
+// export default defineConfig(viteBaseConfig);
+
 const config = {
   plugins: [
     solidPlugin({
@@ -50,7 +61,8 @@ const config = {
     alias: {
       theme: path.resolve(__dirname, '../../l3-ui-theme-base/theme.js'),
       utils: path.resolve(__dirname, '../../shared/utils/index.ts'),
-      types: path.resolve(__dirname, '../types/')
+      types: path.resolve(__dirname, '../types/'),
+      assets: path.resolve(__dirname, '../assets/')
     },
     dedupe: ['solid-js', '@lightningtv/solid']
   },

--- a/packages/solid/components/Artwork/Artwork.tsx
+++ b/packages/solid/components/Artwork/Artwork.tsx
@@ -17,7 +17,7 @@
 
 import { type Component, createMemo } from 'solid-js';
 import { View } from '@lightningtv/solid';
-import type { Tone } from 'types/types.js';
+import type { Tone } from '../../types/types.js';
 import styles from './Artwork.styles.js';
 import type { ArtworkProps } from './Artwork.types.js';
 

--- a/packages/solid/components/Artwork/Artwork.types.ts
+++ b/packages/solid/components/Artwork/Artwork.types.ts
@@ -15,8 +15,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Effects, NodeProps, NodeStyles } from '@lightningtv/solid';
-import type { ComponentStyleConfig, NodeStyleSet, Tone } from 'types/types.js';
-import type { UIComponentProps } from 'types/interfaces.js';
+import type { ComponentStyleConfig, NodeStyleSet, Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
 
 export interface ArtworkProps extends UIComponentProps, ArtworkStyleProperties {
   /** dynamic shader effects applied to the root node */

--- a/packages/solid/components/Badge/Badge.stories.tsx
+++ b/packages/solid/components/Badge/Badge.stories.tsx
@@ -19,7 +19,7 @@ import Icon from '../Icon/Icon.jsx';
 import Badge, { BadgeContainer } from './Badge.jsx';
 import { Text } from '@lightningtv/solid';
 import styles from './Badge.styles.js';
-const lightning = '/assets/images/ic_lightning_white_32.png';
+const lightning = 'assets/images/ic_lightning_white_32.png';
 
 const meta = {
   title: 'Components/Badge',
@@ -69,7 +69,9 @@ export const BadgeIcon = {
           height={25}
           marginLeft={10}
         />
-        <Text marginLeft={6} style={[styles.Text.tones[args.tone ?? styles.tone], styles.Text.base]}>{args.title}</Text>
+        <Text marginLeft={6} style={[styles.Text.tones[args.tone ?? styles.tone], styles.Text.base]}>
+          {args.title}
+        </Text>
       </BadgeContainer>
     );
   },

--- a/packages/solid/components/Badge/Badge.types.ts
+++ b/packages/solid/components/Badge/Badge.types.ts
@@ -17,8 +17,8 @@
  */
 
 import type { NodeStyles, TextProps } from '@lightningtv/solid';
-import type { ComponentStyleConfig, NodeStyleSet, Tone, TextStyleSet } from 'types/types.js';
-import type { UIComponentProps } from 'types/interfaces.js';
+import type { ComponentStyleConfig, NodeStyleSet, Tone, TextStyleSet } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
 
 export interface BadgeProps extends UIComponentProps, BadgeStyleProperties {
   /**

--- a/packages/solid/components/Button/Button.stories.tsx
+++ b/packages/solid/components/Button/Button.stories.tsx
@@ -21,8 +21,8 @@ import { Text } from '@lightningtv/solid';
 import Icon from '../Icon/Icon.jsx';
 import Checkbox from '../Checkbox/Checkbox.jsx';
 
-const lightning = '/assets/images/ic_lightning_white_32.png';
-const check = '/assets/images/check-icon.png';
+const lightning = 'assets/images/ic_lightning_white_32.png';
+const check = 'assets/images/check-icon.png';
 
 type Story = StoryObj<typeof Button>;
 

--- a/packages/solid/components/Button/Button.types.ts
+++ b/packages/solid/components/Button/Button.types.ts
@@ -12,13 +12,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import type { NodeProps, NodeStyles, TextProps, TextStyles } from '@lightningtv/solid';
-import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet, Tone } from 'types/types.js';
-import type { UIComponentProps } from 'types/interfaces.js';
+import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet, Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
 
 export interface ButtonProps extends UIComponentProps, ButtonStyleProperties {
   children: TextProps['children'];

--- a/packages/solid/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/solid/components/Checkbox/Checkbox.stories.tsx
@@ -18,7 +18,7 @@ import Checkbox from './Checkbox.jsx';
 import Icon from '../Icon/Icon.jsx';
 import checkboxStyles from '../Checkbox/Checkbox.styles.js';
 
-const icon = '/assets/images/ic_lightning_white_32.png';
+const icon = 'assets/images/ic_lightning_white_32.png';
 
 const meta = {
   title: 'Components/Checkbox',

--- a/packages/solid/components/Checkbox/Checkbox.tsx
+++ b/packages/solid/components/Checkbox/Checkbox.tsx
@@ -21,7 +21,7 @@ import styles from './Checkbox.styles.js';
 import Icon from '../Icon/Icon.jsx';
 import type { CheckboxProps } from './Checkbox.types.js';
 
-const check = '/assets/images/check-icon.png';
+const check = 'assets/images/check-icon.png';
 
 const Checkbox: Component<CheckboxProps> = (props: CheckboxProps) => {
   return (

--- a/packages/solid/components/Checkbox/Checkbox.types.ts
+++ b/packages/solid/components/Checkbox/Checkbox.types.ts
@@ -15,8 +15,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { NodeProps, NodeStyles } from '@lightningtv/solid';
-import type { ComponentStyleConfig, NodeStyleSet, Tone } from 'types/types.js';
-import type { UIComponentProps } from 'types/interfaces.js';
+import type { ComponentStyleConfig, NodeStyleSet, Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
 
 export interface CheckboxProps extends UIComponentProps, CheckboxStyleProperties {
   /**

--- a/packages/solid/components/Column/Column.stories.tsx
+++ b/packages/solid/components/Column/Column.stories.tsx
@@ -16,7 +16,7 @@
  */
 
 import Column from './Column.jsx';
-import type { NavigableProps } from 'types/Navigable.types.js';
+import type { NavigableProps } from '../../types/Navigable.types.js';
 import Button from '../Button/Button.jsx';
 import type { JSX } from 'solid-js/jsx-runtime';
 import { View } from '@lightningtv/solid';

--- a/packages/solid/components/Column/Column.styles.ts
+++ b/packages/solid/components/Column/Column.styles.ts
@@ -16,7 +16,7 @@
  */
 import theme from 'theme';
 import { makeComponentStyles } from '../../utils/index.js';
-import type { NavigableStyles, NavigableConfig } from 'types/Navigable.types.js';
+import type { NavigableStyles, NavigableConfig } from '../../types/Navigable.types.js';
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
 const { Column: { defaultTone, ...themeStyles } = { themeStyles: {} } } = theme?.componentConfig;

--- a/packages/solid/components/Column/Column.types.ts
+++ b/packages/solid/components/Column/Column.types.ts
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { KeyHandler } from '@lightningtv/core/focusManager';
-import type { NavigableProps, NavigableStyleProperties } from 'types/Navigable.types.js';
+import type { NavigableProps, NavigableStyleProperties } from '../../types/Navigable.types.js';
 
 export interface ColumnProps extends NavigableProps, NavigableStyleProperties {
   /** function to be called on down click */

--- a/packages/solid/components/FocusRing/FocusRing.types.ts
+++ b/packages/solid/components/FocusRing/FocusRing.types.ts
@@ -15,8 +15,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { UIComponentProps } from 'types/interfaces.js';
-import type { ComponentStyleConfig, NodeStyleSet, Tone } from 'types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
+import type { ComponentStyleConfig, NodeStyleSet, Tone } from '../../types/types.js';
 import type { NodeStyles } from '@lightningtv/solid';
 
 export interface FocusRingProps extends UIComponentProps {

--- a/packages/solid/components/Icon/Icon.stories.tsx
+++ b/packages/solid/components/Icon/Icon.stories.tsx
@@ -17,7 +17,7 @@
 
 import Icon from './Icon.jsx';
 import type { Meta, StoryObj } from 'storybook-solidjs';
-import lightning from '../../assets/images/ic_lightning_white_32.png';
+import lightning from 'assets/images/ic_lightning_white_32.png';
 import { hexColor } from '@lightningtv/solid';
 
 type Story = StoryObj<typeof Icon>;

--- a/packages/solid/components/Input/Input.types.ts
+++ b/packages/solid/components/Input/Input.types.ts
@@ -17,8 +17,8 @@
  */
 
 import type { NodeStyles } from '@lightningtv/solid';
-import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet, Tone } from 'types/types.js';
-import type { UIComponentProps } from 'types/interfaces.js';
+import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet, Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
 import type { Signal } from 'solid-js';
 
 export interface InputProps extends UIComponentProps, InputStyleProperties {

--- a/packages/solid/components/Key/Key.types.ts
+++ b/packages/solid/components/Key/Key.types.ts
@@ -15,8 +15,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { NodeProps, NodeStyles, TextStyles } from '@lightningtv/solid';
-import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet, Tone } from 'types/types.js';
-import type { UIComponentProps } from 'types/interfaces.js';
+import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet, Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
 
 export interface KeyProps extends UIComponentProps, KeyStyleProperties {
   /**

--- a/packages/solid/components/Keyboard/Keyboard.types.ts
+++ b/packages/solid/components/Keyboard/Keyboard.types.ts
@@ -15,8 +15,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { NodeStyles } from '@lightningtv/solid';
-import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet, Tone } from 'types/types.js';
-import type { UIComponentProps } from 'types/interfaces.js';
+import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet, Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
 import type { KeyProps, KeySizes } from '../Key/Key.types.js';
 import type { Signal } from 'solid-js';
 

--- a/packages/solid/components/Label/Label.types.ts
+++ b/packages/solid/components/Label/Label.types.ts
@@ -15,8 +15,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { NodeStyles } from '@lightningtv/solid';
-import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet, Tone } from 'types/types.js';
-import type { UIComponentProps } from 'types/interfaces.js';
+import type { ComponentStyleConfig, NodeStyleSet, TextStyleSet, Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
 
 export interface LabelProps extends UIComponentProps, LabelStyleProperties {
   /**

--- a/packages/solid/components/ProgressBar/ProgressBar.types.ts
+++ b/packages/solid/components/ProgressBar/ProgressBar.types.ts
@@ -12,13 +12,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import type { NodeStyles } from '@lightningtv/solid';
-import type { ComponentStyleConfig, NodeStyleSet, Tone } from 'types/types.js';
-import type { UIComponentProps } from 'types/interfaces.js';
+import type { ComponentStyleConfig, NodeStyleSet, Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
 
 export interface ProgressBarProps extends UIComponentProps, ProgressBarStyleProperties {
   /**

--- a/packages/solid/components/Radio/Radio.types.ts
+++ b/packages/solid/components/Radio/Radio.types.ts
@@ -15,8 +15,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { BorderStyleObject, NodeProps, NodeStyles } from '@lightningtv/solid';
-import type { ComponentStyleConfig, NodeStyleSet, Tone } from 'types/types.js';
-import type { UIComponentProps } from 'types/interfaces.js';
+import type { ComponentStyleConfig, NodeStyleSet, Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
 
 export interface RadioProps extends UIComponentProps, RadioStyleProperties {
   /**

--- a/packages/solid/components/Row/Row.styles.ts
+++ b/packages/solid/components/Row/Row.styles.ts
@@ -16,7 +16,7 @@
  */
 import theme from 'theme';
 import { makeComponentStyles } from '../../utils/index.js';
-import type { NavigableConfig, NavigableStyles } from 'types/Navigable.types.js';
+import type { NavigableConfig, NavigableStyles } from '../../types/Navigable.types.js';
 
 /* @ts-expect-error next-line themes are supplied by client applications so this setup is necessary */
 const { Row: { defaultTone, ...themeStyles } = { themeStyles: {} } } = theme?.componentConfig;

--- a/packages/solid/components/Row/Row.tsx
+++ b/packages/solid/components/Row/Row.tsx
@@ -21,7 +21,7 @@ import { chainFunctions } from '../../utils/chainFunctions.js';
 import { handleNavigation, handleOnSelect, onGridFocus } from '../../utils/handleNavigation.js';
 import { withScrolling } from '../../utils/withScrolling.js';
 import styles from './Row.styles.js';
-import type { NavigableProps } from 'types/Navigable.types.js';
+import type { NavigableProps } from '../../types/Navigable.types.js';
 
 const Row: Component<NavigableProps> = props => {
   const onLeft = handleNavigation('left');

--- a/packages/solid/components/Row/Row.types.ts
+++ b/packages/solid/components/Row/Row.types.ts
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { KeyHandler } from '@lightningtv/core/focusManager';
-import type { NavigableProps, NavigableStyleProperties } from 'types/Navigable.types.js';
+import type { NavigableProps, NavigableStyleProperties } from '../../types/Navigable.types.js';
 
 export interface ColumnProps extends NavigableProps, NavigableStyleProperties {
   /** function to be called on down click */

--- a/packages/solid/components/Toggle/Toggle.types.ts
+++ b/packages/solid/components/Toggle/Toggle.types.ts
@@ -15,8 +15,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { NodeProps, NodeStyles, BorderStyleObject } from '@lightningtv/solid';
-import type { ComponentStyleConfig, NodeStyleSet, Tone } from 'types/types.js';
-import type { UIComponentProps } from 'types/interfaces.js';
+import type { ComponentStyleConfig, NodeStyleSet, Tone } from '../../types/types.js';
+import type { UIComponentProps } from '../../types/interfaces.js';
 
 export interface ToggleProps extends UIComponentProps, ToggleStyleProperties {
   /**

--- a/packages/solid/index.stories.ts
+++ b/packages/solid/index.stories.ts
@@ -1,0 +1,2 @@
+export * as ArtworkStories from './components/Artwork/Artwork.stories.js';
+import './components/Artwork/Artwork.mdx';

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "start": "npm run dev",
     "dev": "pnpm run storybook",
-    "build-lib": "tsc -b && tsc-alias",
+    "build-lib": "tsc -b",
     "build-storybook": "storybook build",
     "prepack": "npm run build-lib",
     "storybook": "storybook dev -p 6006",

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -13,8 +13,7 @@
     "skipLibCheck": true,
     "types": ["solid-js", "vite/client"],
     "paths": {
-      "theme": ["../l3-ui-theme-base/theme.d.ts"],
-      "types": ["./types/*"]
+      "theme": ["../l3-ui-theme-base/theme.d.ts"]
     }
   }
 }

--- a/packages/solid/utils/handleNavigation.ts
+++ b/packages/solid/utils/handleNavigation.ts
@@ -17,7 +17,7 @@
 
 import { ElementNode, assertTruthy } from '@lightningtv/core';
 import { type KeyHandler } from '@lightningtv/core/focusManager';
-import { type NavigableElement } from 'types/Navigable.types.js';
+import { type NavigableElement } from '../types/Navigable.types.js';
 
 export function onGridFocus(this: ElementNode) {
   if (!this || this.children.length === 0) return false;

--- a/packages/solid/vite.config.js
+++ b/packages/solid/vite.config.js
@@ -51,7 +51,6 @@ const config = {
     alias: {
       theme: path.resolve(__dirname, '../l3-ui-theme-base/theme.js'),
       utils: path.resolve(__dirname, '../shared/utils/index.ts'),
-      types: path.resolve(__dirname, './types/'),
       assets: path.resolve(__dirname, '../assets/')
     },
     dedupe: ['solid-js', '@lightningtv/solid']

--- a/packages/solid/vite.config.js
+++ b/packages/solid/vite.config.js
@@ -51,7 +51,8 @@ const config = {
     alias: {
       theme: path.resolve(__dirname, '../l3-ui-theme-base/theme.js'),
       utils: path.resolve(__dirname, '../shared/utils/index.ts'),
-      types: path.resolve(__dirname, './types/')
+      types: path.resolve(__dirname, './types/'),
+      assets: path.resolve(__dirname, '../assets/')
     },
     dedupe: ['solid-js', '@lightningtv/solid']
   },


### PR DESCRIPTION
## Description

This PR removes our types alias to make usage in other projects simpler, and adds an asset alias to allow for simpler referencing of images.

## Testing

things should function the same, but now the FPSCounter story should work correctly
