### PR TITLE
fix: Use componentRef after we figure out componentRef

### DIFF
--- a/packages/solid/utils/withScrolling.ts
+++ b/packages/solid/utils/withScrolling.ts
@@ -35,12 +35,11 @@ export function withScrolling(isRow: boolean) {
     selectedElement?: ElementNode | ElementText,
     lastSelected?: number
   ) => {
-    if (!componentRef.children.length) return;
-
     if (typeof selected !== 'number') {
       componentRef = selected;
       selected = 0;
     }
+    if (!componentRef.children.length) return;
     const gap = componentRef.gap || 0;
     const scroll = componentRef.scroll || 'auto';
 


### PR DESCRIPTION
## Description

Forgot to move this after updating component ref in the next if statement now that withScrolling can be called with index first