### PR TITLE
fix: update Row type, export navigable interface

### DIFF
--- a/packages/solid/components/Row/Row.tsx
+++ b/packages/solid/components/Row/Row.tsx
@@ -21,9 +21,9 @@ import { chainFunctions } from '../../utils/chainFunctions.js';
 import { handleNavigation, handleOnSelect, onGridFocus } from '../../utils/handleNavigation.js';
 import { withScrolling } from '../../utils/withScrolling.js';
 import styles from './Row.styles.js';
-import type { NavigableProps } from '../../types/Navigable.types.js';
+import type { RowProps } from './Row.types.js';
 
-const Row: Component<NavigableProps> = props => {
+const Row: Component<RowProps> = props => {
   const onLeft = handleNavigation('left');
   const onRight = handleNavigation('right');
   const scroll = withScrolling(true);

--- a/packages/solid/components/Row/Row.types.ts
+++ b/packages/solid/components/Row/Row.types.ts
@@ -19,7 +19,7 @@
 import type { KeyHandler } from '@lightningtv/core/focusManager';
 import type { NavigableProps, NavigableStyleProperties } from '../../types/Navigable.types.js';
 
-export interface ColumnProps extends NavigableProps, NavigableStyleProperties {
+export interface RowProps extends NavigableProps, NavigableStyleProperties {
   /** function to be called on down click */
   onLeft?: KeyHandler;
 

--- a/packages/solid/index.ts
+++ b/packages/solid/index.ts
@@ -87,3 +87,4 @@ export { FPSCounter, setupFPS, resetCounter } from './components/FPSCounter/inde
 export * from './utils/index.js';
 export * from './types/types.js';
 export * from './types/interfaces.js';
+export * from './types/Navigable.types.js';


### PR DESCRIPTION
## Description

This PR renames the RowProps interface back to Row from Column, updates the Row to reference RowProps instead of NavigableProps, and updates index.ts to export the Navigable interface

## Changes

<!-- A bulleted list of all the changes(anything that might not have been covered in the description) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
