### PR TITLE
fix: export types from Row and Column index

### DIFF
--- a/packages/solid/components/Column/index.ts
+++ b/packages/solid/components/Column/index.ts
@@ -17,3 +17,4 @@
 
 export { default as default } from './Column.jsx';
 export { default as columnStyles } from './Column.styles.js';
+export type { ColumnProps } from './Column.types.js';

--- a/packages/solid/components/Row/index.ts
+++ b/packages/solid/components/Row/index.ts
@@ -16,3 +16,4 @@
  */
 export { default as default } from './Row.jsx';
 export { default as rowStyles } from './Row.styles.js';
+export type { RowProps } from './Row.types.js';


### PR DESCRIPTION
## Description

Add statements to export the RowProps and ColumnProps types from their respective packages

## Changes

<!-- A bulleted list of all the changes(anything that might not have been covered in the description) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
