### PR TITLE
fix: Optimize reuse on Row and Column helpers

### DIFF
--- a/packages/solid/components/Column/Column.tsx
+++ b/packages/solid/components/Column/Column.tsx
@@ -23,11 +23,10 @@ import { chainFunctions } from '../../utils/chainFunctions.js';
 import type { ColumnProps } from './Column.types.js';
 import styles from './Column.styles.js';
 
+const onUp = handleNavigation('up');
+const onDown = handleNavigation('down');
+const scroll = withScrolling(false);
 const Column: Component<ColumnProps> = props => {
-  const onUp = handleNavigation('up');
-  const onDown = handleNavigation('down');
-  const scroll = withScrolling(false);
-
   return (
     <View
       {...props}

--- a/packages/solid/components/Row/Row.tsx
+++ b/packages/solid/components/Row/Row.tsx
@@ -23,11 +23,11 @@ import { withScrolling } from '../../utils/withScrolling.js';
 import styles from './Row.styles.js';
 import type { RowProps } from './Row.types.js';
 
-const Row: Component<RowProps> = props => {
-  const onLeft = handleNavigation('left');
-  const onRight = handleNavigation('right');
-  const scroll = withScrolling(true);
+const onLeft = handleNavigation('left');
+const onRight = handleNavigation('right');
+const scroll = withScrolling(true);
 
+const Row: Component<RowProps> = props => {
   return (
     <View
       {...props}


### PR DESCRIPTION
Move creation of functions outside of component definition so they may be reused for multiple instances.