### PR TITLE
fix: use memo for styles on Row and column to not reapply style object

### DIFF
--- a/packages/solid/components/Column/Column.tsx
+++ b/packages/solid/components/Column/Column.tsx
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type Component } from 'solid-js';
+import { type Component, createMemo } from 'solid-js';
 import { View } from '@lightningtv/solid';
 import { handleNavigation, onGridFocus, handleOnSelect } from '../../utils/handleNavigation.js';
 import { withScrolling } from '../../utils/withScrolling.js';
@@ -27,6 +27,11 @@ const onUp = handleNavigation('up');
 const onDown = handleNavigation('down');
 const scroll = withScrolling(false);
 const Column: Component<ColumnProps> = props => {
+  const mergedStyle = createMemo(() => [
+    props.style,
+    styles.Container.tones[props.tone ?? styles.tone],
+    styles.Container.base
+  ]);
   return (
     <View
       {...props}
@@ -43,11 +48,7 @@ const Column: Component<ColumnProps> = props => {
         props.onSelectedChanged,
         props.scroll !== 'none' ? scroll : undefined
       )}
-      style={[
-        props.style, //
-        styles.Container.tones[props.tone ?? styles.tone],
-        styles.Container.base
-      ]}
+      style={mergedStyle()}
     />
   );
 };

--- a/packages/solid/components/Row/Row.tsx
+++ b/packages/solid/components/Row/Row.tsx
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { type Component } from 'solid-js';
+import { type Component, createMemo } from 'solid-js';
 import { View } from '@lightningtv/solid';
 import { chainFunctions } from '../../utils/chainFunctions.js';
 import { handleNavigation, handleOnSelect, onGridFocus } from '../../utils/handleNavigation.js';
@@ -28,6 +28,11 @@ const onRight = handleNavigation('right');
 const scroll = withScrolling(true);
 
 const Row: Component<RowProps> = props => {
+  const mergedStyle = createMemo(() => [
+    props.style,
+    styles.Container.tones[props.tone ?? styles.tone],
+    styles.Container.base
+  ]);
   return (
     <View
       {...props}
@@ -44,11 +49,7 @@ const Row: Component<RowProps> = props => {
         props.onSelectedChanged,
         props.scroll !== 'none' ? scroll : undefined
       )}
-      style={[
-        props.style, //
-        styles.Container.tones[props.tone ?? styles.tone],
-        styles.Container.base
-      ]}
+      style={mergedStyle()}
     />
   );
 };


### PR DESCRIPTION
Any props on Column causes all props on Column to be recalculated since style array changes.